### PR TITLE
Add configurable skip-disabled-users mapper option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Custom Keycloak LDAP mapper that adds imported LDAP users to a Keycloak group wh
 ## What it does
 
 - Runs during LDAP user import/sync (`onImportUserFromLDAP`).
+- Can skip disabled users (configurable with `Skip Disabled Users`, default `true`).
 - Checks email first using a configured LDAP/AD email attribute key and regex.
 - Builds a normalized payload of LDAP attributes in `attribute=value` lines.
 - Evaluates one regex against that payload (case-sensitive or case-insensitive).
@@ -50,6 +51,7 @@ In your LDAP user federation provider, add this mapper and set:
 - `LDAP Attributes Regex`: regex evaluated against all LDAP attributes in `attribute=value` lines.
 - `Keycloak Group Path`: target group path (example: `/employees/engineering`).
 - `Case-Insensitive Match`: `true` or `false`.
+- `Skip Disabled Users`: `true` or `false` (default `true`).
 
 ## Wiki
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -37,6 +37,7 @@ bin/kc.sh start
 - `LDAP Attributes Regex`
 - `Keycloak Group Path`
 - `Case-Insensitive Match`
+- `Skip Disabled Users` (default `true`)
 
 ## Wiki pages
 

--- a/src/main/java/io/github/ehsanmsb/keycloak/ldap/conditional/LdapConditionalMapper.java
+++ b/src/main/java/io/github/ehsanmsb/keycloak/ldap/conditional/LdapConditionalMapper.java
@@ -22,6 +22,12 @@ public class LdapConditionalMapper extends AbstractLDAPStorageMapper {
 
     @Override
     public void onImportUserFromLDAP(LDAPObject ldapUser, UserModel user, RealmModel realm, boolean isCreate) {
+        boolean skipDisabledUsers = getBooleanConfig(LdapConditionalMapperFactory.SKIP_DISABLED_USERS, true);
+        if (skipDisabledUsers && !user.isEnabled()) {
+            LOG.debugf("User '%s' is disabled. Skipping conditional group sync.", user.getUsername());
+            return;
+        }
+
         String emailAttribute = mapperModel.getConfig().getFirst(LdapConditionalMapperFactory.EMAIL_ATTRIBUTE);
         String emailRegex = mapperModel.getConfig().getFirst(LdapConditionalMapperFactory.EMAIL_REGEX);
         String ldapAttributesRegex = mapperModel.getConfig().getFirst(LdapConditionalMapperFactory.LDAP_ATTRIBUTES_REGEX);
@@ -93,5 +99,13 @@ public class LdapConditionalMapper extends AbstractLDAPStorageMapper {
 
     private boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private boolean getBooleanConfig(String key, boolean defaultValue) {
+        String rawValue = mapperModel.getConfig().getFirst(key);
+        if (rawValue == null || rawValue.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(rawValue);
     }
 }

--- a/src/main/java/io/github/ehsanmsb/keycloak/ldap/conditional/LdapConditionalMapperFactory.java
+++ b/src/main/java/io/github/ehsanmsb/keycloak/ldap/conditional/LdapConditionalMapperFactory.java
@@ -17,6 +17,7 @@ public class LdapConditionalMapperFactory extends AbstractLDAPStorageMapperFacto
     public static final String LDAP_ATTRIBUTES_REGEX = "ldap.attributes.regex";
     public static final String GROUP_PATH = "keycloak.group.path";
     public static final String IGNORE_CASE = "match.ignore.case";
+    public static final String SKIP_DISABLED_USERS = "skip.disabled.users";
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES;
 
@@ -63,6 +64,16 @@ public class LdapConditionalMapperFactory extends AbstractLDAPStorageMapperFacto
         ignoreCase.setDefaultValue("true");
         ignoreCase.setHelpText("When enabled, both email regex and LDAP attributes regex matching ignore case.");
         properties.add(ignoreCase);
+
+        ProviderConfigProperty skipDisabledUsers = new ProviderConfigProperty();
+        skipDisabledUsers.setName(SKIP_DISABLED_USERS);
+        skipDisabledUsers.setLabel("Skip Disabled Users");
+        skipDisabledUsers.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        skipDisabledUsers.setDefaultValue("true");
+        skipDisabledUsers.setHelpText(
+            "When enabled, disabled users are skipped and are not synced to the configured group."
+        );
+        properties.add(skipDisabledUsers);
 
         CONFIG_PROPERTIES = Collections.unmodifiableList(properties);
     }


### PR DESCRIPTION
## Summary
- add Skip Disabled Users mapper toggle (default true)
- skip group sync for disabled users when enabled
- update README and wiki Home

Closes #2 
Relates to #1 